### PR TITLE
EBP-958: Turn on cert validation by default for secure connections

### DIFF
--- a/src/main/java/com/solace/samples/javarto/features/SecureSessionConfiguration.java
+++ b/src/main/java/com/solace/samples/javarto/features/SecureSessionConfiguration.java
@@ -10,8 +10,8 @@ public class SecureSessionConfiguration extends SessionConfiguration {
 	private String ciphers;
 	private String trustStoreDir;
 	private String commonNames;
-	private boolean validateCertificates = false;
-	private boolean validateCertificateDates = false;
+	private boolean validateCertificates = true;
+	private boolean validateCertificateDates = true;
 	private String sslDowngrade;
 	private String privateKeyFile;
 	private String privateKeyPassword;

--- a/src/main/java/com/solace/samples/javarto/features/common/SecureSessionConfiguration.java
+++ b/src/main/java/com/solace/samples/javarto/features/common/SecureSessionConfiguration.java
@@ -11,8 +11,8 @@ public class SecureSessionConfiguration extends SessionConfiguration {
 	private String ciphers;
 	private String trustStoreDir;
 	private String commonNames;
-	private boolean validateCertificates = false;
-	private boolean validateCertificateDates = false;
+	private boolean validateCertificates = true;
+	private boolean validateCertificateDates = true;
 	private String sslDowngrade;
 	private String privateKeyFile;
 	private String privateKeyPassword;


### PR DESCRIPTION
Overview:
The certificate validation for secure connections should be turned on by default based on the [documentation](https://github.com/SolaceSamples/solace-samples-javarto/blob/master/src/main/java/com/solace/samples/javarto/features/ArgumentsParser.java#L321) but is turned off. 

Enabling the validation as part of this PR